### PR TITLE
Link to changelog and migration guide that exists.

### DIFF
--- a/assets/templates/pages/support/SupportHomePage.html
+++ b/assets/templates/pages/support/SupportHomePage.html
@@ -61,8 +61,11 @@
         <ul>
           <li>
             <strong>
-              <a href="#/documentation/changelog/0.11">0.10 -> 0.11 Migration Guide</a>
+              <a href="https://github.com/balderdashy/sails/blob/f1d01e316a30ee2c18e782e345edb6686eb8e4bd/0.11-migration-guide.md">0.10 -> 0.11 Migration Guide</a>
             </strong>
+          </li>
+          <li>
+            <a href="https://github.com/balderdashy/sails/blob/f1d01e316a30ee2c18e782e345edb6686eb8e4bd/CHANGELOG.md#0110">0.11.0 Changelog</a>
           </li>
         </ul>
         <h5>0.10.x</h5>


### PR DESCRIPTION
The current link to the 0.11.0 migration guides does not work and the link to the changelog does not exist. So at least linking to the github versions of these.